### PR TITLE
Document more breaking changes for resolver output types

### DIFF
--- a/docs/releases/9.0.0.md
+++ b/docs/releases/9.0.0.md
@@ -20,6 +20,7 @@
   - [Changed Resolver `updateById` input args](#changed-resolver-updatebyid-input-args)
   - [`createMany` resolver now validates all records before save](#createmany-resolver-now-validates-all-records-before-save)
   - [Some generated types were renamed](#some-generated-types-were-renamed)
+  - [`findMany` and `findByIds` changed output type](#findMany-and-findbyids-output-type-nonnull)
 - [Misc](#misc)
 - [Thanks](#thanks)
   - [Thanks to contributors](#thanks-to-contributors)
@@ -608,6 +609,10 @@ Before 9.0.0, `graphql-compose-mongoose` would save some records provided to `cr
 
 - type for `filter._operators` field. Was `OperatorsXXXFilterInput`, which now becomes `XXXFilterOperatorsInput`. This helps keep all generated types with the same prefix for `XXX` entity.
 - in the `count` resolver, we changed the `filter` type name from `Filter` to `FilterCount`. All other resolvers already had `FilterFindMany`, `FilterFindOne`, etc. names; only the `count` resolver did not follow this pattern.
+
+### `findMany` and `findByIds` output type NonNull
+- Output type for the `findMany` resolver is now NonNull of List of NonNull of (WrappedType)
+- Used to be List of NonNull of (WrappedType)
 
 ## Misc
 


### PR DESCRIPTION
@nodkz I hope this is ok - while migrating to v9 I saw my wrappers stopped working for some resolvers and it seems like I only expected 2 wrappings around the internal type - "non null" and "list" but now there is also another "non null" around the whole output.